### PR TITLE
feat: add rust version of qtox-updater-genkeys

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -26,6 +26,7 @@ set -eu -o pipefail
 
 build_rust_bits() {
     local rusty_bits=(
+        qtox-updater-genkeys
         qtox-updater-sign
     )
 

--- a/qtox-updater-genkeys/Cargo.lock
+++ b/qtox-updater-genkeys/Cargo.lock
@@ -1,0 +1,47 @@
+[root]
+name = "qtox-updater-genkeys"
+version = "0.1.0"
+dependencies = [
+ "sodiumoxide 0.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libsodium-sys"
+version = "0.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "sodiumoxide"
+version = "0.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libsodium-sys 0.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.7.15 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[metadata]
+"checksum libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "a51822fc847e7a8101514d1d44e354ba2ffa7d4c194dcab48870740e327cac70"
+"checksum libsodium-sys 0.0.12 (registry+https://github.com/rust-lang/crates.io-index)" = "44e9986c330611ccd26ea74e502c70e5ebab2874c4c23f2f5f3c5a6ed3fbfbc6"
+"checksum pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8cee804ecc7eaf201a4a207241472cc870e825206f6c031e3ee2a72fa425f2fa"
+"checksum serde 0.7.15 (registry+https://github.com/rust-lang/crates.io-index)" = "1b0e0732aa8ec4267f61815a396a942ba3525062e3bd5520aa8419927cfc0a92"
+"checksum sodiumoxide 0.0.12 (registry+https://github.com/rust-lang/crates.io-index)" = "8d9da099120def269669aa349e0c3e97de4ab2c5cb9a54a765041651dd0055eb"

--- a/qtox-updater-genkeys/Cargo.toml
+++ b/qtox-updater-genkeys/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "qtox-updater-genkeys"
+version = "0.1.0"
+authors = ["Zetok Zalbavar <zetok@openmailbox.org>"]
+
+[dependencies]
+sodiumoxide = "0.0.12"

--- a/qtox-updater-genkeys/README.md
+++ b/qtox-updater-genkeys/README.md
@@ -1,0 +1,6 @@
+# qtox-updater-genkeys
+
+Simple program for generating public and secret keys for signing releases.
+
+Creates files named `qtox-updater-skey` and `qtox-updater-pkey` in working
+directory that contain secret and public keys respectively.

--- a/qtox-updater-genkeys/src/main.rs
+++ b/qtox-updater-genkeys/src/main.rs
@@ -1,0 +1,69 @@
+/*
+    Copyright © 2017 by The qTox Project Contributors
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+extern crate sodiumoxide;
+
+use std::io::prelude::*;
+use std::fs::{self, File};
+use std::os::unix::fs::PermissionsExt;
+
+use sodiumoxide::crypto::sign::*;
+
+/// files that contains secret/public keys
+const SECRET_KEY_FNAME: &'static str = "qtox-updater-skey";
+const PUBLIC_KEY_FNAME: &'static str = "qtox-updater-pkey";
+
+
+/// Supply `mode` as octet, e.g. `0o640`
+fn set_permission(file: &File, mode: u32) {
+    let mut perms = file.metadata()
+        .expect("Failed to get file metadata")
+        .permissions();
+    perms.set_mode(mode);
+
+    drop(fs::set_permissions(SECRET_KEY_FNAME, perms)
+        .expect(&format!("Failed to set {:o} permissions on {}",
+                mode, SECRET_KEY_FNAME)));
+}
+
+
+fn main() {
+    let mut skey_file = File::create(SECRET_KEY_FNAME)
+        .expect(&format!("Failed to open {}", SECRET_KEY_FNAME));
+    let mut pkey_file = File::create(PUBLIC_KEY_FNAME)
+        .expect(&format!("Failed to open {}", PUBLIC_KEY_FNAME));
+
+    // set secret key file as rw only by the owner
+    set_permission(&skey_file, 0o600);
+
+    // make sure to init sodiumoxide for proper entropy
+    if !sodiumoxide::init() {
+        println!("Failed to initialize sodiumoxide, something is very wrong. \
+                 Aborting");
+        ::std::process::exit(1)
+    }
+
+    let (pk, sk): (PublicKey, SecretKey) = gen_keypair();
+
+    skey_file.write_all(&sk.0).expect("Failed to write SecretKey");
+    // secret key file should be read-only by owner
+    set_permission(&skey_file, 0o400);
+
+    pkey_file.write_all(&pk.0).expect("Failed to write PublicKey");
+
+    println!("Wrote new keys to disk");
+}


### PR DESCRIPTION
Submitted previously to qTox/qTox#4040, but it was decided that updater
tools should live in a separate repo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox-updater-tools/2)
<!-- Reviewable:end -->
