### PR TITLE
chore(travis): cache cargo dependencies on travis to speed up builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ rust:
   - stable
   - beta
   - nightly
+cache:
+ directories:
+   - $HOME/.cargo
+   - $TRAVIS_BUILD_DIR/qtox-updater-genkeys/target
+   - $TRAVIS_BUILD_DIR/qtox-updater-sign/target
 
 # regex is for release tags
 branches:


### PR DESCRIPTION

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox-updater-tools/4)
<!-- Reviewable:end -->

Edit: docs: https://docs.travis-ci.com/user/caching/#Rust-Cargo-cache